### PR TITLE
Empty meta data should be null issue30

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ gradle-app.setting
 # IntelliJ specific files
 .idea
 *.iml
+out
 
 
 # Maven 

--- a/src/main/java/com/authenteq/builders/BigchainDbTransactionBuilder.java
+++ b/src/main/java/com/authenteq/builders/BigchainDbTransactionBuilder.java
@@ -169,7 +169,7 @@ public class BigchainDbTransactionBuilder {
 	public static class Builder implements IAssetMetaData, IBuild {
 
 		/** The metadata. */
-		private Map<String, String> metadata = new TreeMap<String, String>();
+		private Map<String, String> metadata = null;
 		
 		/** The assets. */
 		private Map<String, String> assets = new TreeMap<String, String>();
@@ -194,6 +194,8 @@ public class BigchainDbTransactionBuilder {
 		 */
 		@Override
 		public IAssetMetaData addMetaData(String key, String value) {
+			if( this.metadata == null )
+				this.metadata = new TreeMap<String, String>();
 			this.metadata.put(key, value);
 			return this;
 		}
@@ -212,6 +214,8 @@ public class BigchainDbTransactionBuilder {
 		 */
 		@Override
 		public IAssetMetaData addMetaData(Map<String, String> metadata) {
+			if( this.metadata == null )
+				this.metadata = new TreeMap<String, String>();
 			this.metadata.putAll(metadata);
 			return this;
 		}
@@ -363,6 +367,8 @@ public class BigchainDbTransactionBuilder {
 		public IAssetMetaData addMetaData(DataModel obj) {
 			Type mapType = new TypeToken<Map<String, String>>(){}.getType();  
 			Map<String, String> son = JsonUtils.getGson().fromJson(JsonUtils.toJson(obj), mapType);
+			if( this.metadata == null )
+				this.metadata = new TreeMap<String, String>();
 			this.metadata.putAll(son);
 			return this;
 		}

--- a/src/main/java/com/authenteq/model/Transaction.java
+++ b/src/main/java/com/authenteq/model/Transaction.java
@@ -30,7 +30,7 @@ public class Transaction implements Serializable {
 
 	/** The meta data. */
 	@SerializedName("metadata")
-	private Map<String, String> metaData = new TreeMap<String, String>();
+	private Map<String, String> metaData = null;
 
 	/** The operation. */
 	@SerializedName("operation")
@@ -218,6 +218,8 @@ public class Transaction implements Serializable {
 	 * @return the transaction
 	 */
 	public Transaction addMetaData(String key, String value) {
+		if( this.metaData == null )
+			this.metaData = new TreeMap<String, String>();
 		this.metaData.put(key, value);
 		return this;
 	}

--- a/src/main/java/com/authenteq/util/GsonEmptyCheckTypeAdapterFactory.java
+++ b/src/main/java/com/authenteq/util/GsonEmptyCheckTypeAdapterFactory.java
@@ -1,0 +1,57 @@
+package com.authenteq.util;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.TypeAdapter;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonWriter;
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * Change empty Maps to null
+ * Source http://chrisjenx.com/gson-empty-json-to-null/
+ */
+public class GsonEmptyCheckTypeAdapterFactory implements TypeAdapterFactory
+{
+	@Override
+	public <T> TypeAdapter<T> create(final Gson gson, final TypeToken<T> type) {
+		// We filter out the EmptyCheckTypeAdapter as we need to check this for emptiness!
+		if (Map.class.isAssignableFrom( type.getRawType() )) {
+			final TypeAdapter<T> delegate = gson.getDelegateAdapter(this, type);
+			final TypeAdapter<JsonElement> elementAdapter = gson.getAdapter(JsonElement.class);
+			return new EmptyCheckTypeAdapter<>(delegate, elementAdapter).nullSafe();
+		}
+		return null;
+	}
+
+	static public class EmptyCheckTypeAdapter<T> extends TypeAdapter<T>
+	{
+		private final TypeAdapter<T> delegate;
+		private final TypeAdapter<JsonElement> elementAdapter;
+
+		public EmptyCheckTypeAdapter( final TypeAdapter<T> delegate, final TypeAdapter<JsonElement> elementAdapter )
+		{
+			this.delegate = delegate;
+			this.elementAdapter = elementAdapter;
+		}
+
+		@Override
+		public void write( final JsonWriter out, final T value ) throws IOException
+		{
+			this.delegate.write( out, value );
+		}
+
+		@Override
+		public T read( final JsonReader in ) throws IOException
+		{
+			final JsonObject asJsonObject = elementAdapter.read( in ).getAsJsonObject();
+			if( asJsonObject.entrySet().isEmpty() )
+				return null;
+			return this.delegate.fromJsonTree( asJsonObject );
+		}
+	}
+}

--- a/src/main/java/com/authenteq/util/JsonUtils.java
+++ b/src/main/java/com/authenteq/util/JsonUtils.java
@@ -8,7 +8,6 @@ import com.authenteq.model.Votes;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
-
 /**
  * Utility class for handling JSON serialization and deserialization.
  * 
@@ -39,6 +38,7 @@ public class JsonUtils {
 					.registerTypeAdapter(Assets.class, new AssetsDeserializer())
 					.registerTypeAdapter(Outputs.class, new OutputsDeserializer())
 					.registerTypeAdapter(Votes.class, new VoteDeserializer())
+					.registerTypeAdapterFactory(new GsonEmptyCheckTypeAdapterFactory())
 					.setExclusionStrategies(new CustomExclusionStrategy()).create();
 		}
 		return gson;

--- a/src/test/java/com/authenteq/BigchaindbTransactionTest.java
+++ b/src/test/java/com/authenteq/BigchaindbTransactionTest.java
@@ -19,7 +19,10 @@
 
 package com.authenteq;
 
+import com.authenteq.builders.BigchainDbTransactionBuilder;
+import com.authenteq.model.Transaction;
 import com.authenteq.model.TransactionModel;
+import com.authenteq.util.JsonUtils;
 import com.authenteq.util.KeyPairUtils;
 import net.i2p.crypto.eddsa.EdDSAEngine;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
@@ -35,13 +38,14 @@ import org.interledger.cryptoconditions.types.Ed25519Sha256Condition;
 import org.interledger.cryptoconditions.types.Ed25519Sha256Fulfillment;
 import org.json.JSONObject;
 import org.junit.Test;
+import sun.security.util.KeyUtil;
 
 import java.security.*;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
-
+import static org.junit.Assert.assertNull;
 
 /**
  * The Class BigchaindbTransactionTest.
@@ -195,6 +199,22 @@ public class BigchaindbTransactionTest {
         assertEquals(SHOULD_BE_PUBLIC_KEY, publicEncoded);
         assertTrue(transactionSigned.isSigned());
         assertFalse(transactionUnsigned.isSigned());
+    }
+
+    /**
+     * Test empty meta-data in transaction is null
+     */
+    @Test
+    public void transactionMetaDataIsNull() {
+        KeyPair alice = KeyPairUtils.generateNewKeyPair();
+        
+        Transaction transaction = BigchainDbTransactionBuilder.init()
+                                      .addAsset( "owner", "alice" )
+                                      .buildAndSignOnly( (EdDSAPublicKey) alice.getPublic(), (EdDSAPrivateKey) alice.getPrivate() );
+
+        assertTrue( transaction.toString().contains( "\"metadata\": null" ) );
+        Transaction tx = JsonUtils.fromJson( transaction.toString(), Transaction.class );
+        assertNull( tx.getMetaData() );
     }
 
     /**


### PR DESCRIPTION
Convert empty maps to null when being serialised to JSON. 
Empty maps are rejected by the BigchainDB