### PR TITLE
Asset and meta data as obj issue 36

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,12 @@ jdk:
   - oraclejdk8
 install: true
 
+before_script:
+  - mvn install:install-file -Dfile=$TRAVIS_BUILD_DIR/libs/java-crypto-conditions-2.0.0-SNAPSHOT.jar -DgroupId=org.interledger -DartifactId=java-crypto-conditions -Dversion=2.0.0-SNAPSHOT -Dpackaging=jar
+
 branches:
   only:
-  - master
+  - AssetAndMetaData-as-Obj-Issue-36
 
 script:
   - mvn clean install

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_script:
 
 branches:
   only:
-  - AssetAndMetaData-as-Obj-Issue-36
+  - master
 
 script:
   - mvn clean install

--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,6 @@
 			<version>1.10</version>
 		</dependency>
 		<dependency>
-			<groupId>org.json</groupId>
-			<artifactId>json</artifactId>
-			<version>20170516</version>
-		</dependency>
-		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.8.2</version>

--- a/src/main/java/com/authenteq/api/TransactionsApi.java
+++ b/src/main/java/com/authenteq/api/TransactionsApi.java
@@ -10,7 +10,6 @@ import com.authenteq.util.JsonUtils;
 import com.authenteq.util.NetworkUtils;
 import okhttp3.RequestBody;
 import okhttp3.Response;
-import org.json.JSONException;
 
 import java.io.IOException;
 import java.util.logging.Logger;
@@ -75,20 +74,16 @@ public class TransactionsApi extends AbstractApi {
 	 * @param operation
 	 *            the operation
 	 * @return the transactions by asset id
-	 * @throws JSONException
-	 *             the JSON exception
 	 * @throws IOException
 	 *             Signals that an I/O exception has occurred.
 	 */
 	public static Transactions getTransactionsByAssetId(String assetId, Operations operation)
-			throws JSONException, IOException {
+			throws IOException {
 		LOGGER.info("getTransactionsByAssetId Call :" + assetId + " operation " + operation);
 		Response response = NetworkUtils.sendGetRequest(
 				BigChainDBGlobals.getBaseUrl() + BigchainDbApi.TRANSACTIONS + "?asset_id=" + assetId + "&operation=" + operation);
 		String body = response.body().string();
 		response.close();
 		return JsonUtils.fromJson(body, Transactions.class);
-
 	}
-
 }

--- a/src/main/java/com/authenteq/builders/BigchainDbConfigBuilder.java
+++ b/src/main/java/com/authenteq/builders/BigchainDbConfigBuilder.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
-import com.authenteq.api.AccountApi;
 import com.authenteq.constants.BigchainDbApi;
 import com.authenteq.model.ApiEndpoints;
 import com.authenteq.model.BigChainDBGlobals;
@@ -25,9 +24,8 @@ import okhttp3.Response;
  * The Class BigchainDbConfigBuilder.
  */
 public class BigchainDbConfigBuilder {
-	
-	private static final Logger LOGGER = Logger.getLogger(AccountApi.class.getName());
-	
+
+	private static final Logger LOGGER = Logger.getLogger(BigchainDbConfigBuilder.class.getName());
 	/**
 	 * Instantiates a new bigchain db config builder.
 	 */
@@ -74,11 +72,6 @@ public class BigchainDbConfigBuilder {
 		 * Setup.
 		 */
 		void setup();
-
-		/**
-		 * Setup.
-		 */
-
 	}
 
 	/**

--- a/src/main/java/com/authenteq/json/strategy/AssetSerializer.java
+++ b/src/main/java/com/authenteq/json/strategy/AssetSerializer.java
@@ -1,0 +1,32 @@
+package com.authenteq.json.strategy;
+
+import com.authenteq.model.Asset;
+import com.authenteq.util.JsonUtils;
+import com.google.gson.*;
+
+import java.lang.reflect.Type;
+
+public class AssetSerializer implements JsonSerializer<Asset>
+{
+	/**
+	 *  Serialize an asset object to json object
+	 *  Note: given the type of the asset.data it maybe necessary to
+	 *  to add a type adapter {@link JsonSerializer} and/or {@link JsonDeserializer} with {@link JsonUtils} and
+	 *  {@link com.authenteq.util.JsonUtils#addTypeAdapterSerializer}
+	 *
+	 *  TODO test user.data with custom serializer
+	 *
+	 * @param src object to serialize
+	 * @param typeOfSrc type of src
+	 * @param context the json context
+	 * @return the json object
+	 */
+	public JsonElement serialize( Asset src, Type typeOfSrc, JsonSerializationContext context )
+	{
+		Gson gson = JsonUtils.getGson();
+		JsonObject asset = new JsonObject();
+		asset.add( "data", gson.toJsonTree( src.getData(), src.getDataClass() ) );
+		
+		return asset;
+	}
+}

--- a/src/main/java/com/authenteq/json/strategy/AssetsDeserializer.java
+++ b/src/main/java/com/authenteq/json/strategy/AssetsDeserializer.java
@@ -9,9 +9,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
-import java.util.Iterator;
-
-
 
 /**
  * The Class AssetsDeserializer.
@@ -26,9 +23,7 @@ public class AssetsDeserializer implements JsonDeserializer<Assets> {
 			throws JsonParseException {
 		
 		Assets assets = new Assets();
-		Iterator<JsonElement> jsonIter = json.getAsJsonArray().iterator();
-		while(jsonIter.hasNext()) {
-			JsonElement jElement = jsonIter.next();
+		for( JsonElement jElement: json.getAsJsonArray() ) {
 			assets.addAsset(JsonUtils.fromJson(jElement.getAsJsonObject().toString(), Asset.class));
 		}
 		return assets;

--- a/src/main/java/com/authenteq/json/strategy/TransactionDeserializer.java
+++ b/src/main/java/com/authenteq/json/strategy/TransactionDeserializer.java
@@ -10,13 +10,23 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
-import java.util.Iterator;
 import java.util.Map;
 
 /**
  * The Class TransactionsDeserializer.
  */
 public class TransactionDeserializer implements JsonDeserializer<Transaction> {
+	private static Class metaDataClass = Map.class;
+
+	/**
+	 * Set a custom metadata class the class that is serialized should be symmetrical with the class that is deserialized.
+	 *
+	 * @param metaDataType the metaData class
+	 */
+	public static void setMetaDataClass( Class metaDataType )
+	{
+		metaDataClass = metaDataType;
+	}
 
 	/*
 	 * (non-Javadoc)
@@ -27,37 +37,26 @@ public class TransactionDeserializer implements JsonDeserializer<Transaction> {
 	 */
 	@SuppressWarnings("unchecked")
 	@Override
-	public Transaction deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-			throws JsonParseException {
-
-		// while(jsonIter.hasNext()) {
+	public Transaction deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException
+	{
 		Transaction transaction = new Transaction();
 		JsonElement jElement = json.getAsJsonObject();
 
-		transaction.setAsset(JsonUtils.fromJson(jElement.getAsJsonObject().get("asset").toString(), Asset.class));
-		transaction.setMetaData((Map<String, String>) JsonUtils
-				.fromJson(jElement.getAsJsonObject().get("metadata").toString(), Map.class));
+		transaction.setAsset( JsonUtils.fromJson(jElement.getAsJsonObject().get("asset").toString(), Asset.class));
+		transaction.setMetaData( JsonUtils.fromJson( jElement.getAsJsonObject().get("metadata").toString(), metaDataClass ));
 		transaction.setId(jElement.getAsJsonObject().get("id").toString().replace("\"", ""));
 
-		Iterator<JsonElement> jInputElementIter = jElement.getAsJsonObject().get("inputs").getAsJsonArray().iterator();
-
-		while (jInputElementIter.hasNext()) {
-			JsonElement jInputElement = jInputElementIter.next();
+		for( JsonElement jInputElement: jElement.getAsJsonObject().get("inputs").getAsJsonArray() ) {
 			transaction.addInput(JsonUtils.fromJson(jInputElement.toString(), Input.class));
 		}
 
-		Iterator<JsonElement> jOutputElementIter = jElement.getAsJsonObject().get("outputs").getAsJsonArray()
-				.iterator();
-
-		while (jOutputElementIter.hasNext()) {
-			JsonElement jOutputElement = jOutputElementIter.next();
+		for( JsonElement jOutputElement: jElement.getAsJsonObject().get("outputs").getAsJsonArray() ) {
 			transaction.addOutput(JsonUtils.fromJson(jOutputElement.toString(), Output.class));
 		}
 
 		transaction.setOperation(jElement.getAsJsonObject().get("operation").toString());
 		transaction.setVersion(jElement.getAsJsonObject().get("version").toString());
-
-		// }
+		
 		return transaction;
 	}
 }

--- a/src/main/java/com/authenteq/json/strategy/TransactionIdExclusionStrategy.java
+++ b/src/main/java/com/authenteq/json/strategy/TransactionIdExclusionStrategy.java
@@ -1,0 +1,18 @@
+package com.authenteq.json.strategy;
+
+import com.authenteq.model.Transaction;
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+public class TransactionIdExclusionStrategy implements ExclusionStrategy
+{
+	public boolean shouldSkipClass( Class<?> klass )
+	{
+		return false;
+	}
+
+	public boolean shouldSkipField( FieldAttributes f )
+	{
+		return f.getDeclaringClass() == Transaction.class && f.getName().equals( "id" );
+	}
+}

--- a/src/main/java/com/authenteq/json/strategy/TransactionsDeserializer.java
+++ b/src/main/java/com/authenteq/json/strategy/TransactionsDeserializer.java
@@ -8,15 +8,18 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 
 import java.lang.reflect.Type;
-import java.util.Iterator;
 import java.util.Map;
-
-
 
 /**
  * The Class TransactionsDeserializer.
  */
 public class TransactionsDeserializer implements JsonDeserializer<Transactions> {
+	private static Class metaDataClass = Map.class;
+
+	public static void setMetaDataClass( Class metaDataType )
+	{
+		metaDataClass = metaDataType;
+	}
 
 	/* (non-Javadoc)
 	 * @see com.google.gson.JsonDeserializer#deserialize(com.google.gson.JsonElement, java.lang.reflect.Type, com.google.gson.JsonDeserializationContext)
@@ -27,26 +30,19 @@ public class TransactionsDeserializer implements JsonDeserializer<Transactions> 
 			throws JsonParseException {
 		
 		Transactions transactions = new Transactions();
-		Iterator<JsonElement> jsonIter = json.getAsJsonArray().iterator();
-		while(jsonIter.hasNext()) {
+
+		for( JsonElement jElement: json.getAsJsonArray() ) {
 			Transaction transaction = new Transaction();
-			JsonElement jElement = jsonIter.next();
 			
 			transaction.setAsset(JsonUtils.fromJson(jElement.getAsJsonObject().get("asset").toString(), Asset.class));
-			transaction.setMetaData((Map<String,String>)JsonUtils.fromJson(jElement.getAsJsonObject().get("metadata").toString(), Map.class));
+			transaction.setMetaData( JsonUtils.fromJson( jElement.getAsJsonObject().get("metadata").toString(), metaDataClass ));
 			transaction.setId(jElement.getAsJsonObject().get("id").toString());
-			
-			Iterator<JsonElement> jInputElementIter = jElement.getAsJsonObject().get("inputs").getAsJsonArray().iterator();
-			
-			while(jInputElementIter.hasNext()) {
-				JsonElement jInputElement = jInputElementIter.next();
+
+			for( JsonElement jInputElement: jElement.getAsJsonObject().get("inputs").getAsJsonArray() ) {
 				transaction.addInput(JsonUtils.fromJson(jInputElement.toString(), Input.class));
 			}
-			
-			Iterator<JsonElement> jOutputElementIter = jElement.getAsJsonObject().get("outputs").getAsJsonArray().iterator();
-			
-			while(jOutputElementIter.hasNext()) {
-				JsonElement jOutputElement = jOutputElementIter.next();
+
+			for( JsonElement jOutputElement: jElement.getAsJsonObject().get("outputs").getAsJsonArray() ) {
 				transaction.addOutput(JsonUtils.fromJson(jOutputElement.toString(), Output.class));
 			}
 			

--- a/src/main/java/com/authenteq/model/Asset.java
+++ b/src/main/java/com/authenteq/model/Asset.java
@@ -4,12 +4,8 @@ import com.authenteq.annotations.Exclude;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
-import java.util.Map;
-import java.util.TreeMap;
 
-
-
-/**
+/*
  * The Class Asset.
  */
 public class Asset implements Serializable {
@@ -26,7 +22,11 @@ public class Asset implements Serializable {
 	
 	/** The data. */
 	@SerializedName("data")
-	private Map<String,String> data;
+	private Object data;
+
+	/** the data class the type of the data class needed for serialization/deserialization */
+	@Exclude
+	private Class dataClass;
 
 	/**
 	 * Instantiates a new asset.
@@ -37,9 +37,11 @@ public class Asset implements Serializable {
 	 * Instantiates a new asset.
 	 *
 	 * @param data the data
+	 * @param dataClass due to type erasure the data class needs to be provided for serialization/deserialization
 	 */
-	public Asset(Map<String,String> data) {
+	public Asset(Object data, Class dataClass ) {
 		this.data = data;
+		this.dataClass = dataClass;
 	}
 	
 	/**
@@ -47,17 +49,18 @@ public class Asset implements Serializable {
 	 *
 	 * @return the data
 	 */
-	public Map<String, String> getData() {
+	public Object getData() {
 		return data;
 	}
 
 	/**
-	 * Sets the data.
+	 * return the type of the Asset data class
 	 *
-	 * @param data the data
+	 * @return  the data class type
 	 */
-	public void setData(Map<String, String> data) {
-		this.data = data;
+	public Class getDataClass()
+	{
+		return dataClass;
 	}
 
 	/**
@@ -77,23 +80,4 @@ public class Asset implements Serializable {
 	public void setId(String id) {
 		this.id = id;
 	}
-	
-	
-	/**
-	 * Adds the asset.
-	 *
-	 * @param key the key
-	 * @param value the value
-	 * @return the asset
-	 */
-	public Asset addAsset(String key, String value) {
-		if(this.data == null) {
-			this.data = new TreeMap<String,String>();
-		}
-		this.data.put(key, value);
-		return this;
-	}
-	
-	
-
 }

--- a/src/main/java/com/authenteq/model/Transaction.java
+++ b/src/main/java/com/authenteq/model/Transaction.java
@@ -1,16 +1,13 @@
 package com.authenteq.model;
 
 import com.authenteq.annotations.Exclude;
+import com.authenteq.json.strategy.TransactionIdExclusionStrategy;
 import com.authenteq.util.JsonUtils;
 import com.google.gson.annotations.SerializedName;
 
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
-
-
 
 /**
  * The Class Transaction.
@@ -27,11 +24,11 @@ public class Transaction implements Serializable {
 
 	/** The inputs. */
 	@SerializedName("inputs")
-	private List<Input> inputs = new ArrayList<Input>();
+	private List<Input> inputs = new ArrayList<>();
 
 	/** The meta data. */
 	@SerializedName("metadata")
-	private Map<String, String> metaData = null;
+	private Object metaData = null;
 
 	/** The operation. */
 	@SerializedName("operation")
@@ -39,7 +36,7 @@ public class Transaction implements Serializable {
 
 	/** The outputs. */
 	@SerializedName("outputs")
-	private List<Output> outputs = new ArrayList<Output>();
+	private List<Output> outputs = new ArrayList<>();
 
 	/** The version. */
 	@SerializedName("version")
@@ -126,17 +123,18 @@ public class Transaction implements Serializable {
 	 *
 	 * @return the meta data
 	 */
-	public Map<String, String> getMetaData() {
+	public Object getMetaData() {
 		return metaData;
 	}
 
 	/**
-	 * Sets the meta data.
+	 * Set the metaData object
 	 *
-	 * @param metaData the meta data
+	 * @param obj the metadata object
 	 */
-	public void setMetaData(Map<String, String> metaData) {
-		this.metaData = metaData;
+	public void setMetaData( Object obj )
+	{
+		this.metaData = obj;
 	}
 
 	/**
@@ -211,25 +209,21 @@ public class Transaction implements Serializable {
 		this.outputs.add(output);
 	}
 
-	/**
-	 * Adds the meta data.
-	 *
-	 * @param key the key
-	 * @param value the value
-	 * @return the transaction
-	 */
-	public Transaction addMetaData(String key, String value) {
-		if( this.metaData == null )
-			this.metaData = new TreeMap<String, String>();
-		this.metaData.put(key, value);
-		return this;
-	}
-
 	 /* (non-Javadoc)
  	 * @see java.lang.Object#toString()
  	 */
  	@Override
 	 public String toString() {
 		 return JsonUtils.toJson(this);
+	 }
+
+	/**
+	 * Return the transaction suitable for hashing.
+	 *
+	 * @return the transaction as a json string
+	 */
+	public String toHashInput()
+	 {
+	 	return JsonUtils.toJson( this, new TransactionIdExclusionStrategy() );
 	 }
 }

--- a/src/main/java/com/authenteq/model/TransactionModel.java
+++ b/src/main/java/com/authenteq/model/TransactionModel.java
@@ -22,6 +22,10 @@ package com.authenteq.model;
 import com.authenteq.util.Base58;
 import com.authenteq.util.DriverUtils;
 import com.authenteq.util.KeyPairUtils;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
+import com.google.gson.JsonObject;
 import net.i2p.crypto.eddsa.EdDSAEngine;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
@@ -32,15 +36,10 @@ import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.interledger.cryptoconditions.types.Ed25519Sha256Condition;
 import org.interledger.cryptoconditions.types.Ed25519Sha256Fulfillment;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
 
 import java.security.*;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.List;
-
 
 /**
  * The Class Transaction.
@@ -51,13 +50,13 @@ public class TransactionModel {
 	private EdDSAPublicKey publicKey;
 	
 	/** The data. */
-	private JSONObject data;
+	private JsonObject data;
 	
 	/** The metadata. */
-	private JSONObject metadata;
+	private JsonObject metadata;
 	
 	/** The transaction json. */
-	private JSONObject transactionJson;
+	private JsonObject transactionJson;
 	
 	/** The signed. */
 	private boolean signed;
@@ -70,10 +69,10 @@ public class TransactionModel {
 	 *            (can be `null` if not needed)
 	 * @param publicKey the public key
 	 */
-	public TransactionModel(JSONObject data, JSONObject metadata, EdDSAPublicKey publicKey) {
+	public TransactionModel(JsonObject data, JsonObject metadata, EdDSAPublicKey publicKey) {
 		this.publicKey = publicKey;
-		this.data = DriverUtils.makeSelfSorting(data);
-		this.metadata = DriverUtils.makeSelfSorting(metadata);
+		this.data = DriverUtils.makeSelfSortingGson(data);
+		this.metadata = DriverUtils.makeSelfSortingGson(metadata);
 		buildTransactionJson();
 	}
 
@@ -86,12 +85,12 @@ public class TransactionModel {
 	 * @param publicKey the public key
 	 * @param signed the signed
 	 */
-	private TransactionModel(JSONObject data, JSONObject metadata, JSONObject transactionJson,
-			EdDSAPublicKey publicKey, boolean signed) {
+	private TransactionModel( JsonObject data, JsonObject metadata, JsonObject transactionJson,
+	                          EdDSAPublicKey publicKey, boolean signed) {
 		this.publicKey = publicKey;
-		this.data = DriverUtils.makeSelfSorting(data);
-		this.metadata = DriverUtils.makeSelfSorting(metadata);
-		this.transactionJson = DriverUtils.makeSelfSorting(transactionJson);
+		this.data = DriverUtils.makeSelfSortingGson(data);
+		this.metadata = DriverUtils.makeSelfSortingGson(metadata);
+		this.transactionJson = DriverUtils.makeSelfSortingGson(transactionJson);
 		this.signed = signed;
 	}
 
@@ -99,50 +98,50 @@ public class TransactionModel {
 	 * Builds the transaction JSON without actually signing it.
 	 */
 	protected void buildTransactionJson() {
-		JSONObject asset = DriverUtils.getSelfSortingJson();
-		JSONObject outputs = DriverUtils.getSelfSortingJson();
-		JSONObject inputs = DriverUtils.getSelfSortingJson();
-		JSONObject condition = DriverUtils.getSelfSortingJson();
-		JSONObject details = DriverUtils.getSelfSortingJson();
-		JSONArray inputsArr = new JSONArray();
-		JSONArray outputsArr = new JSONArray();
+		JsonObject asset = DriverUtils.getSelfSortingJson();
+		JsonObject outputs = DriverUtils.getSelfSortingJson();
+		JsonObject inputs = DriverUtils.getSelfSortingJson();
+		JsonObject condition = DriverUtils.getSelfSortingJson();
+		JsonObject details = DriverUtils.getSelfSortingJson();
+		JsonArray inputsArr = new JsonArray();
+		JsonArray outputsArr = new JsonArray();
 
 		Ed25519Sha256Condition condition1 = new Ed25519Sha256Condition(publicKey);
 
-		JSONObject rootObject = DriverUtils.getSelfSortingJson();
+		JsonObject rootObject = DriverUtils.getSelfSortingJson();
 		try {
 			if (metadata == null) {
-				rootObject.put("metadata", JSONObject.NULL);
+				rootObject.add("metadata", null);
 			} else {
-				rootObject.put("metadata", metadata);
+				rootObject.add("metadata", metadata);
 			}
 
-			rootObject.put("operation", "CREATE");
-			rootObject.put("version", "1.0");
-			asset.put("data", data);
-			rootObject.put("asset", asset);
+			rootObject.addProperty("operation", "CREATE");
+			rootObject.addProperty("version", "1.0");
+			asset.add("data", data);
+			rootObject.add("asset", asset);
 
-			outputs.put("amount", "1");
-			JSONArray publicKeys = new JSONArray();
-			publicKeys.put(KeyPairUtils.encodePublicKeyInBase58(publicKey));
-			outputs.put("public_keys", publicKeys);
-			outputsArr.put(outputs);
-			rootObject.put("outputs", outputsArr);
+			outputs.addProperty("amount", "1");
+			JsonArray publicKeys = new JsonArray();
+			publicKeys.add(KeyPairUtils.encodePublicKeyInBase58(publicKey));
+			outputs.add("public_keys", publicKeys);
+			outputsArr.add(outputs);
+			rootObject.add("outputs", outputsArr);
 
-			condition.put("uri", condition1.getUri().toString());
+			condition.addProperty("uri", condition1.getUri().toString());
 
-			details.put("public_key", KeyPairUtils.encodePublicKeyInBase58(publicKey));
-			details.put("type", "ed25519-sha-256");
-			condition.put("details", details);
-			outputs.put("condition", condition);
+			details.addProperty("public_key", KeyPairUtils.encodePublicKeyInBase58(publicKey));
+			details.addProperty("type", "ed25519-sha-256");
+			condition.add("details", details);
+			outputs.add("condition", condition);
 
-			inputs.put("fulfillment", JSONObject.NULL);
-			inputs.put("fulfills", JSONObject.NULL);
-			JSONArray ownersBefore = new JSONArray();
-			ownersBefore.put(KeyPairUtils.encodePublicKeyInBase58(publicKey));
-			inputs.put("owners_before", ownersBefore);
-			inputsArr.put(inputs);
-			rootObject.put("inputs", inputsArr);
+			inputs.add("fulfillment", null);
+			inputs.add("fulfills", null);
+			JsonArray ownersBefore = new JsonArray();
+			ownersBefore.add(KeyPairUtils.encodePublicKeyInBase58(publicKey));
+			inputs.add("owners_before", ownersBefore);
+			inputsArr.add(inputs);
+			rootObject.add("inputs", inputsArr);
 
 			// getting SHA3 hash of the current JSON object
 			SHA3.DigestSHA3 md = new SHA3.DigestSHA3(256);
@@ -150,8 +149,8 @@ public class TransactionModel {
 			String id = DriverUtils.getHex(md.digest());
 
 			// putting the hash as id field
-			rootObject.put("id", id);
-		} catch (JSONException e) {
+			rootObject.addProperty("id", id);
+		} catch (Exception e) {
 			e.printStackTrace();
 		}
 		
@@ -166,7 +165,7 @@ public class TransactionModel {
 	 *         fulfillment
 	 */
 	public String getTransactionId() {
-		return transactionJson.getString("id");
+		return transactionJson.get("id").getAsString();
 	}
 
 	/**
@@ -184,10 +183,10 @@ public class TransactionModel {
 			edDsaSigner.update(transactionJson.toString().getBytes());
 			byte[] signature = edDsaSigner.sign();
 			Ed25519Sha256Fulfillment fulfillment = new Ed25519Sha256Fulfillment(publicKey, signature);
-			JSONObject inputs = transactionJson.getJSONArray("inputs").getJSONObject(0);
-			inputs.put("fulfillment", Base64.encodeBase64URLSafeString(fulfillment.getEncoded()));
+			JsonObject inputs = transactionJson.get("inputs").getAsJsonArray().get( 0 ).getAsJsonObject();//   getJsonArray("inputs").getJSONObject(0);
+			inputs.addProperty("fulfillment", Base64.encodeBase64URLSafeString(fulfillment.getEncoded()));
 			signed = true;
-		} catch (JSONException | NoSuchAlgorithmException e) {
+		} catch ( NoSuchAlgorithmException e) {
 			e.printStackTrace();
 		}
 	}
@@ -206,7 +205,7 @@ public class TransactionModel {
 	 *
 	 * @return The JSON representation of the transaction
 	 */
-	public JSONObject getTransactionJson() {
+	public JsonObject getTransactionJson() {
 		return transactionJson;
 	}
 
@@ -236,7 +235,7 @@ public class TransactionModel {
 	 *
 	 * @return the data
 	 */
-	public JSONObject getData() {
+	public JsonObject getData() {
 		return data;
 	}
 
@@ -245,7 +244,7 @@ public class TransactionModel {
 	 *
 	 * @return the metadata
 	 */
-	public JSONObject getMetadata() {
+	public JsonObject getMetadata() {
 		return metadata;
 	}
 
@@ -257,21 +256,20 @@ public class TransactionModel {
 	 * @param jsonObject the json object
 	 * @return the transaction
 	 */
-	public static TransactionModel createFromJson(JSONObject jsonObject) {
-		JSONObject data = jsonObject.getJSONObject("asset").getJSONObject("data");
-		JSONObject metadata = jsonObject.getJSONObject("metadata");
-		String publicKeyEncoded = jsonObject.getJSONArray("outputs").getJSONObject(0).getJSONArray("public_keys")
-				.getString(0);
+	public static TransactionModel createFromJson(JsonObject jsonObject) {
+		JsonObject data = jsonObject.get("asset").getAsJsonObject().get("data").getAsJsonObject();
+		JsonObject metadata = jsonObject.get("metadata").getAsJsonObject();
+		String publicKeyEncoded = jsonObject.get("outputs").getAsJsonArray().get(0).getAsJsonObject().get("public_keys").getAsJsonArray().get(0).getAsString();
 		byte[] publicKey = Base58.decode(publicKeyEncoded);
 		EdDSAParameterSpec keySpecs = EdDSANamedCurveTable.getByName("Ed25519");
 		EdDSAPublicKeySpec spec = new EdDSAPublicKeySpec(publicKey, keySpecs);
 		EdDSAPublicKey edDSAPublicKey = new EdDSAPublicKey(spec);
 
 		// TODO: validate the signature
-		Object fulfObject = jsonObject.getJSONArray("inputs").getJSONObject(0).get("fulfillment");
+		JsonElement fulfObject = jsonObject.get("inputs").getAsJsonArray().get(0).getAsJsonObject().get("fulfillment");
 
 		boolean signed = false;
-		if (!JSONObject.NULL.equals(fulfObject))
+		if ( ! fulfObject.equals( JsonNull.INSTANCE ) )
 			signed = true;
 
 		return new TransactionModel(data, metadata, jsonObject, edDSAPublicKey, signed);
@@ -283,25 +281,23 @@ public class TransactionModel {
 	 * @param jsonArray the json array
 	 * @return the list
 	 */
-	public static List<TransactionModel> createFromJsonArray(JSONArray jsonArray) {
+	public static List<TransactionModel> createFromJsonArray(JsonArray jsonArray) {
 		List<TransactionModel> bigChaindbTransactionList = new ArrayList<TransactionModel>();
-		Iterator<Object> jsonObjectIter = jsonArray.iterator();
-		while (jsonObjectIter.hasNext()) {
-			JSONObject jsonObject = (JSONObject)jsonObjectIter.next();
-			JSONObject data = jsonObject.getJSONObject("asset").getJSONObject("data");
-			JSONObject metadata = jsonObject.getJSONObject("metadata");
-			String publicKeyEncoded = jsonObject.getJSONArray("outputs").getJSONObject(0).getJSONArray("public_keys")
-					.getString(0);
+		for( JsonElement jsonElement: jsonArray ) {
+			JsonObject jsonObject = jsonElement.getAsJsonObject();
+			JsonObject data = jsonObject.get("asset").getAsJsonObject().get("data").getAsJsonObject();
+			JsonObject metadata = jsonObject.get("metadata").getAsJsonObject();
+			String publicKeyEncoded = jsonObject.get("outputs").getAsJsonArray().get(0).getAsJsonObject().get("public_keys").getAsJsonArray().get(0).getAsString();
 			byte[] publicKey = Base58.decode(publicKeyEncoded);
 			EdDSAParameterSpec keySpecs = EdDSANamedCurveTable.getByName("Ed25519");
 			EdDSAPublicKeySpec spec = new EdDSAPublicKeySpec(publicKey, keySpecs);
 			EdDSAPublicKey edDSAPublicKey = new EdDSAPublicKey(spec);
 
 			// TODO: validate the signature
-			Object fulfObject = jsonObject.getJSONArray("inputs").getJSONObject(0).get("fulfillment");
+			JsonElement fulfObject = jsonObject.get("inputs").getAsJsonArray().get(0).getAsJsonObject().get("fulfillment");
 
 			boolean signed = false;
-			if (!JSONObject.NULL.equals(fulfObject))
+			if ( ! fulfObject.equals( JsonNull.INSTANCE ) )
 				signed = true;
 			
 			bigChaindbTransactionList.add(new TransactionModel(data, metadata, jsonObject, edDSAPublicKey, signed));

--- a/src/main/java/com/authenteq/util/JsonUtils.java
+++ b/src/main/java/com/authenteq/util/JsonUtils.java
@@ -2,27 +2,52 @@ package com.authenteq.util;
 
 import com.authenteq.json.factory.GsonEmptyCheckTypeAdapterFactory;
 import com.authenteq.json.strategy.*;
-import com.authenteq.model.Assets;
-import com.authenteq.model.Outputs;
-import com.authenteq.model.Transactions;
-import com.authenteq.model.Votes;
-import com.google.gson.FieldNamingPolicy;
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.authenteq.model.*;
+import com.google.gson.*;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Utility class for handling JSON serialization and deserialization.
- * 
  */
 public class JsonUtils {
 
 	/** The gson. */
-	private static Gson gson;
+	private static String jsonDateFormat = "yyyy-MM-dd'T'HH:mm:ssX";  // Assumes Java 7 or higher
+
+	private static Map<String, TypeAdapter> typeAdaptersDeserialize = new ConcurrentHashMap<String, TypeAdapter>(16)
+	{{
+		put( Transaction.class.getCanonicalName(), new TypeAdapter( Transaction.class, new TransactionDeserializer() ) );
+		put( Transactions.class.getCanonicalName(), new TypeAdapter( Transactions.class, new TransactionsDeserializer() ) );
+		put( Assets.class.getCanonicalName(), new TypeAdapter( Assets.class, new AssetsDeserializer() ) );
+		put( Outputs.class.getCanonicalName(), new TypeAdapter( Outputs.class, new OutputsDeserializer() ) );
+		put( Votes.class.getCanonicalName(), new TypeAdapter( Votes.class, new VoteDeserializer() ) );
+	}};
+
+	private static Map<String, TypeAdapter> typeAdaptersSerialize = new ConcurrentHashMap<String, TypeAdapter>(16)
+	{{
+		put( Asset.class.getCanonicalName(), new TypeAdapter( Asset.class, new AssetSerializer() ) );
+	}};
 
 	/**
 	 * Instantiates a new json utils.
 	 */
 	private JsonUtils() {
+	}
+	
+	private static synchronized GsonBuilder base()
+	{
+		GsonBuilder builder = new GsonBuilder();
+
+		builder = builder
+			          .serializeNulls()
+			          .disableHtmlEscaping()
+			          .setDateFormat( jsonDateFormat )
+			          .registerTypeAdapterFactory(new GsonEmptyCheckTypeAdapterFactory())
+			          .addSerializationExclusionStrategy(new CustomExclusionStrategy());
+
+		return builder;
 	}
 
 	/**
@@ -31,21 +56,74 @@ public class JsonUtils {
 	 * @return the gson
 	 */
 	public static Gson getGson() {
-		if (gson == null) {
-			GsonBuilder builder = new GsonBuilder();
-			
-			gson = builder.setPrettyPrinting()
-					.serializeNulls()
-					.disableHtmlEscaping()
-					.setPrettyPrinting()
-					.registerTypeAdapter(Transactions.class, new TransactionsDeserializer())
-					.registerTypeAdapter(Assets.class, new AssetsDeserializer())
-					.registerTypeAdapter(Outputs.class, new OutputsDeserializer())
-					.registerTypeAdapter(Votes.class, new VoteDeserializer())
-					.registerTypeAdapterFactory(new GsonEmptyCheckTypeAdapterFactory())
-					.addSerializationExclusionStrategy(new CustomExclusionStrategy()).create();
+		GsonBuilder builder = base();
+
+		for( TypeAdapter value : typeAdaptersDeserialize.values() )
+			builder.registerTypeAdapter( value.getType(), value.getSerializer() );
+
+		for( TypeAdapter value : typeAdaptersSerialize.values() )
+			builder.registerTypeAdapter( value.getType(), value.getSerializer() );
+
+		return builder.create();
+	}
+
+	/**
+	 *
+	 * @return the gson
+	 */
+	public static Gson getGson( ExclusionStrategy... exclusionStrategies ) {
+		return getGson( null, exclusionStrategies );
+	}
+
+	/**
+	 *
+	 * @return the gson
+	 */
+	public static Gson getGson( Class ignoreClass, ExclusionStrategy... exclusionStrategies )
+	{
+		GsonBuilder builder = base();
+
+		for( TypeAdapter value : typeAdaptersDeserialize.values() ) {
+			if( ignoreClass != null && value.getType().equals( ignoreClass ) )
+				continue;
+			builder.registerTypeAdapter( value.getType(), value.getSerializer() );
 		}
-		return gson;
+
+		for( TypeAdapter value : typeAdaptersSerialize.values() ) {
+			if( ignoreClass != null && value.getType().equals( ignoreClass ) )
+				continue;
+
+			builder.registerTypeAdapter( value.getType(), value.getSerializer() );
+		}
+
+		return builder.setExclusionStrategies( exclusionStrategies ).create();
+	}
+
+	public static void setJsonDateFormat( final String dateFormat )
+	{
+		jsonDateFormat = dateFormat;
+	}
+
+	/**
+	 * Add a type adapter
+	 *
+	 * @param type the type (@Class) we're adapting
+	 * @param jsonDeserializer the type's deserializer
+	 */
+	public static void addTypeAdapterDeserializer( Class type, JsonDeserializer<?> jsonDeserializer )
+	{
+		typeAdaptersDeserialize.put( type.getCanonicalName(), new TypeAdapter( type, jsonDeserializer ) );
+	}
+
+	/**
+	 * Add a type adapter
+	 *
+	 * @param type the type (@Class) we're adapting
+	 * @param jsonSerializer the type's deserializer
+	 */
+	public static void addTypeAdapterSerializer( Class type, JsonSerializer<?> jsonSerializer )
+	{
+		typeAdaptersSerialize.put( type.getCanonicalName(), new TypeAdapter( type, jsonSerializer ) );
 	}
 
 	/**
@@ -77,7 +155,20 @@ public class JsonUtils {
 	public static String toJson(Object src) {
 		return getGson().toJson(src);
 	}
-	
+
+	/**
+	 * To json.
+	 *
+	 * @param src
+	 *            the object for which Json representation is to be created
+	 *            setting for Gson .
+	 * @return Json representation of src.
+	 * @see Gson#toJson(Object)
+	 */
+	public static String toJson(Object src, ExclusionStrategy ... exclusionStrategies) {
+		return getGson( exclusionStrategies ).toJson(src);
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -87,5 +178,4 @@ public class JsonUtils {
 	public String toString() {
 		return "JsonUtils []";
 	}
-
 }

--- a/src/main/java/com/authenteq/util/TypeAdapter.java
+++ b/src/main/java/com/authenteq/util/TypeAdapter.java
@@ -1,0 +1,57 @@
+package com.authenteq.util;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonSerializer;
+
+/**
+ * container for storing type sdapter information
+ */
+public class TypeAdapter
+{
+	private Class type;
+	private Object serializer;
+
+	/**
+	 * Contruct a type adapter
+	 *
+	 * @param type the class
+	 * @param serializer its serializer
+	 */
+	TypeAdapter( Class type, JsonDeserializer<?> serializer  )
+	{
+		this.type = type;
+		this.serializer = serializer;
+	}
+
+	/**
+	 * Contruct a type adapter
+	 *
+	 * @param type the class
+	 * @param serializer its serializer
+	 */
+	TypeAdapter( Class type, JsonSerializer<?> serializer )
+	{
+		this.type = type;
+		this.serializer = serializer;
+	}
+
+	/**
+	 * Get the deserializer
+	 *
+	 * @return the deserializer
+	 */
+	public Object getSerializer()
+	{
+		return this.serializer;
+	}
+
+	/**
+	 * Get the class for the deserializer
+	 *
+	 * @return the class
+	 */
+	public Class getType()
+	{
+		return type;
+	}
+}

--- a/src/test/java/com/authenteq/BigchaindbTransactionTest.java
+++ b/src/test/java/com/authenteq/BigchaindbTransactionTest.java
@@ -262,6 +262,8 @@ import com.authenteq.model.Transaction;
 import com.authenteq.model.TransactionModel;
 import com.authenteq.util.JsonUtils;
 import com.authenteq.util.KeyPairUtils;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import net.i2p.crypto.eddsa.EdDSAEngine;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
@@ -274,11 +276,10 @@ import org.apache.commons.codec.binary.Base64;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.interledger.cryptoconditions.types.Ed25519Sha256Condition;
 import org.interledger.cryptoconditions.types.Ed25519Sha256Fulfillment;
-import org.json.JSONObject;
 import org.junit.Test;
-import sun.security.util.KeyUtil;
 
 import java.security.*;
+import java.util.TreeMap;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
@@ -289,9 +290,10 @@ import static org.junit.Assert.assertNull;
  * The Class BigchaindbTransactionTest.
  */
 public class BigchaindbTransactionTest {
-    
+    private JsonParser jsonParser = new JsonParser();
+
     /** The Constant SHOULD_BE_FULFILMENT. */
-    static final String SHOULD_BE_FULFILMENT = "pGSAIOJUaCNTxPOZO2g7x0h6cFHt4LmgrN1LNGXh9q7IDOKxgUDSvX-fMwu6b-VdHQj9plPncX-XiS-VIgBWHPd13hNlB3G-C6grKqzHYGjEGvcJ_fcfD9wy-QHwN4hEfyvebkAM";
+    static final String SHOULD_BE_FULFILMENT = "pGSAIOJUaCNTxPOZO2g7x0h6cFHt4LmgrN1LNGXh9q7IDOKxgUAATCXo2r_eqIeRotaioUYOQzoaZTedmFMzQVfY4VOcCd5VO69SkFO3R6dJ8y-qQ0pEzuHDIOGKILoGOU87iWkI";
     
     /** The Constant JSON_REPR_SIGNED. */
     static final String JSON_REPR_SIGNED = "{\n" +
@@ -381,16 +383,16 @@ public class BigchaindbTransactionTest {
      */
     @Test
     public void transactionGenerationTest() throws Exception {
-        JSONObject data = new JSONObject();
-        data.put("expiration", "NLpPB8MpOkQLZJuyn4rXacdQBXOt4OAwQUSAEpipi2Y=\\n");
-        data.put("lat", "DP\\/p9q4D7L0IBZr53Dh98N1huD5BGG\\/nZ9zs\\/ydEUzc=\\n");
-        data.put("lon", "ZPleIXiR3W4RWzjrdXcqXDYUjPGGQn6JKmMF5OH7T6U=\\n");
-        data.put("firstname", "NLpPB8MpOkQLZJuyn4rXacdQBXOt4OAwQUSAEpipi2Y=\\n");
-        data.put("lastname", "N4iDURp+thKsn1Mn7csSoU63QJnJxqyz+VNOPUikMMk=\\n");
-        data.put("dob", "ZBJhOnJgC\\/E\\/iD2eyh15qWqD3jsyj+k9+2XIDJXvhEE=\\n");
-        data.put("sex", "lg52\\/gnwsTWdwUW4teyj4SGQOF7y5C435on9HtW3DwI=\\n");
-        data.put("nationality", "MjpcaVsVoR+5E5ov4Z2gAal1cUfYLUypL52nFqx7pyM=\\n");
-        data.put("idNumber", "hsDKi81fiXWuNHoZrzezzTMHykjDIrAtiPozzPTkkbM=\\n");
+        JsonObject data = new JsonObject();
+        data.addProperty("expiration", "NLpPB8MpOkQLZJuyn4rXacdQBXOt4OAwQUSAEpipi2Y=\\n");
+        data.addProperty("lat", "DP\\/p9q4D7L0IBZr53Dh98N1huD5BGG\\/nZ9zs\\/ydEUzc=\\n");
+        data.addProperty("lon", "ZPleIXiR3W4RWzjrdXcqXDYUjPGGQn6JKmMF5OH7T6U=\\n");
+        data.addProperty("firstname", "NLpPB8MpOkQLZJuyn4rXacdQBXOt4OAwQUSAEpipi2Y=\\n");
+        data.addProperty("lastname", "N4iDURp+thKsn1Mn7csSoU63QJnJxqyz+VNOPUikMMk=\\n");
+        data.addProperty("dob", "ZBJhOnJgC\\/E\\/iD2eyh15qWqD3jsyj+k9+2XIDJXvhEE=\\n");
+        data.addProperty("sex", "lg52\\/gnwsTWdwUW4teyj4SGQOF7y5C435on9HtW3DwI=\\n");
+        data.addProperty("nationality", "MjpcaVsVoR+5E5ov4Z2gAal1cUfYLUypL52nFqx7pyM=\\n");
+        data.addProperty("idNumber", "hsDKi81fiXWuNHoZrzezzTMHykjDIrAtiPozzPTkkbM=\\n");
 
         KeyPair keyPair = retrieveKeyPair();
 
@@ -405,20 +407,18 @@ public class BigchaindbTransactionTest {
                 (EdDSAPublicKey) keyPair.getPublic());
         Signature edDsaSigner = new EdDSAEngine(MessageDigest.getInstance("SHA-512"));
 
-        JSONObject rootObject = new JSONObject(bigchaindbTransaction.getTransactionJson().toString());
-        String fulfilmentVal = rootObject.getJSONArray("inputs").getJSONObject(0).getString("fulfillment");
-        rootObject.getJSONArray("inputs").getJSONObject(0).put("fulfillment", JSONObject.NULL);
+        JsonObject rootObject = jsonParser.parse( bigchaindbTransaction.getTransactionJson().toString()).getAsJsonObject();
+        String fulfilmentVal = rootObject.get("inputs").getAsJsonArray().get(0).getAsJsonObject().get("fulfillment").getAsString();
+        rootObject.get("inputs").getAsJsonArray().get(0).getAsJsonObject().add("fulfillment", null);
         edDsaSigner.initSign(keyPair.getPrivate());
         edDsaSigner.update(rootObject.toString().getBytes());
         byte[] signature = edDsaSigner.sign();
-        Ed25519Sha256Fulfillment fulfillment
-                = new Ed25519Sha256Fulfillment((EdDSAPublicKey) keyPair.getPublic(), signature);
-        assertEquals("4eff006ca203061d6bc1100959018f008c0f61a4b53c5d8a333159adf69a7c46", rootObject.getString("id"));
-        assertEquals("4eff006ca203061d6bc1100959018f008c0f61a4b53c5d8a333159adf69a7c46", bigchaindbTransaction.getTransactionId());
+        Ed25519Sha256Fulfillment fulfillment = new Ed25519Sha256Fulfillment((EdDSAPublicKey) keyPair.getPublic(), signature);
+        assertEquals("7a9f2830564b8d21acb1579a09c34904b694aeeabe670df20752d4d731ec96ea", rootObject.get("id").getAsString());
+        assertEquals("7a9f2830564b8d21acb1579a09c34904b694aeeabe670df20752d4d731ec96ea", bigchaindbTransaction.getTransactionId());
         assertEquals(SHOULD_BE_FULFILMENT, fulfilmentVal);
 
         assertTrue(fulfillment.verify(condition1, rootObject.toString().getBytes()));
-//        return rootObject.toString();
     }
 
     /**
@@ -428,10 +428,8 @@ public class BigchaindbTransactionTest {
      */
     @Test
     public void transactionFromJson() throws Exception {
-        TransactionModel transactionSigned
-                = TransactionModel.createFromJson(new JSONObject(JSON_REPR_SIGNED));
-        TransactionModel transactionUnsigned
-                = TransactionModel.createFromJson(new JSONObject(JSON_REPR_UNSIGNED));
+        TransactionModel transactionSigned = TransactionModel.createFromJson(jsonParser.parse(JSON_REPR_SIGNED).getAsJsonObject());
+        TransactionModel transactionUnsigned = TransactionModel.createFromJson(jsonParser.parse(JSON_REPR_UNSIGNED).getAsJsonObject());
 
         String publicEncoded = KeyPairUtils.encodePublicKeyInBase58(transactionSigned.getPublicKey());
         assertEquals(SHOULD_BE_PUBLIC_KEY, publicEncoded);
@@ -445,12 +443,13 @@ public class BigchaindbTransactionTest {
     @Test
     public void transactionMetaDataIsNull() {
         KeyPair alice = KeyPairUtils.generateNewKeyPair();
-        
+
+        TreeMap<String, String> assetData = new TreeMap<String, String>() {{ put( "owner", "alice" ); }};
         Transaction transaction = BigchainDbTransactionBuilder.init()
-                                      .addAsset( "owner", "alice" )
+                                      .addAssets( assetData, assetData.getClass() )
                                       .buildAndSignOnly( (EdDSAPublicKey) alice.getPublic(), (EdDSAPrivateKey) alice.getPrivate() );
 
-        assertTrue( transaction.toString().contains( "\"metadata\": null" ) );
+        assertTrue( transaction.toString().contains( "\"metadata\":null" ) );
         Transaction tx = JsonUtils.fromJson( transaction.toString(), Transaction.class );
         assertNull( tx.getMetaData() );
     }

--- a/src/test/java/com/authenteq/api/AssetsApiTest.java
+++ b/src/test/java/com/authenteq/api/AssetsApiTest.java
@@ -4,18 +4,18 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.security.KeyPair;
+import java.util.Map;
+import java.util.TreeMap;
 
-import com.authenteq.AbstractTest;
 import com.authenteq.builders.BigchainDbTransactionBuilder;
+import com.authenteq.json.strategy.AssetSerializer;
+import com.authenteq.model.Asset;
 import com.authenteq.model.Assets;
 import com.authenteq.model.StatusCode;
 import com.authenteq.model.Transaction;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
 import net.i2p.crypto.eddsa.EdDSAPublicKey;
-import org.junit.BeforeClass;
 import org.junit.Test;
-
-import com.authenteq.builders.BigchainDbConfigBuilder;
 
 import static org.junit.Assert.assertEquals;
 
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
  */
 public class AssetsApiTest extends AbstractApiTest
 {
-
 	/**
 	 * Test asset search.
 	 */
@@ -37,10 +36,11 @@ public class AssetsApiTest extends AbstractApiTest
 			// create transaction with unique asset
 			net.i2p.crypto.eddsa.KeyPairGenerator edDsaKpg = new net.i2p.crypto.eddsa.KeyPairGenerator();
 			KeyPair alice = edDsaKpg.generateKeyPair();
+			TreeMap<String, String> assetData = new TreeMap<String, String>() {{ put( "uuid", uuid ); }};
 
 			Transaction transaction = BigchainDbTransactionBuilder
 				                          .init()
-				                          .addAsset( "uuid", uuid )
+				                          .addAssets( assetData, Map.class )
 				                          .buildAndSign( (EdDSAPublicKey) alice.getPublic(), (EdDSAPrivateKey) alice.getPrivate() )
 				                          .sendTransaction();
 			assertEquals( StatusCode.VALID, getStatus( transaction ).getStatus() );    // wait for the transaction to be marked VALID

--- a/src/test/java/com/authenteq/api/BlocksApiTest.java
+++ b/src/test/java/com/authenteq/api/BlocksApiTest.java
@@ -7,6 +7,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.security.KeyPair;
 import java.security.spec.InvalidKeySpecException;
+import java.util.Map;
+import java.util.TreeMap;
 
 import com.authenteq.AbstractTest;
 import org.junit.BeforeClass;
@@ -38,13 +40,21 @@ public class BlocksApiTest extends AbstractApiTest
 	@Test
 	public void testBlockSearch() throws InterruptedException {
 		try {
-		
-			Transaction transaction = BigchainDbTransactionBuilder.init().addAsset("middlename", "mname")
-					.addAsset("firstname", "John").addAsset("giddlename", "mname").addAsset("ziddlename", "mname")
-					.addAsset("lastname", "Smith").addMetaData("what", "My first BigchainDB transaction")
-					.operation(Operations.CREATE).buildAndSign((EdDSAPublicKey) Account.publicKeyFromHex(publicKey),
-							(EdDSAPrivateKey) Account.privateKeyFromHex(privateKey))
-					.sendTransaction();
+			Map<String, String> metaData = new TreeMap<String, String>() {{ put( "what", "My first BigchainDB transaction" ); }};
+			Map<String, String> assetData = new TreeMap<String, String>() {{
+				put( "middlename", "mname" );
+				put("firstname", "John");
+				put( "giddlename", "mname" );
+				put( "ziddlename", "mname" );
+				put( "lastname", "Smith" );
+			}};
+			
+			Transaction transaction = BigchainDbTransactionBuilder
+                      .init()
+                      .addAssets(assetData, TreeMap.class)
+                      .operation(Operations.CREATE)
+                      .buildAndSign((EdDSAPublicKey) Account.publicKeyFromHex(publicKey), (EdDSAPrivateKey) Account.privateKeyFromHex(privateKey))
+                      .sendTransaction();
 			
 			assertFalse(BlocksApi.getBlocks(transaction.getId(), BlockStatus.VALID).isEmpty());
 			

--- a/src/test/java/com/authenteq/api/OutputsApiTest.java
+++ b/src/test/java/com/authenteq/api/OutputsApiTest.java
@@ -29,7 +29,6 @@ public class OutputsApiTest extends AbstractApiTest
 
 	/**
 	 * Test.
-	 * @throws InvalidKeySpecException 
 	 */
 	@Test
 	public void testOutput() throws InvalidKeySpecException {


### PR DESCRIPTION
This is a substantial change:

- removed the dependency on org.json and replaced with gson in driverutils.
- Added the ability to submit custom type adaptors (serializers/deserializers)
- MetaData can now be an arbitrary object
- Asset.Data can now be an arbitrary object
- jsonutils no longer caches gson object, it maybe worth revisiting this in the future, but with custom type adaptors it makes more sense to build the gson object dynamically, removed json pretty printing
- json utils no longer formats json strings al
- added AssetSerializer 
- added Transaction.toHashInput to create the json string for hashing this now uses TransactionIdExclusionStrategy to remove the transaction ID.

Some assorted cleanup.



