### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ install:
 before_script:
  - mvn install:install-file -Dfile=$TRAVIS_BUILD_DIR/libs/java-crypto-conditions-2.0.0-SNAPSHOT.jar -DgroupId=org.interledger -DartifactId=java-crypto-conditions -Dversion=2.0.0-SNAPSHOT -Dpackaging=jar
 
+cache:
+  directories:
+  - $HOME/.m2
+
 branches:
  only:
  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,24 @@
 language: java
-sudo: false
+sudo: required
 jdk:
-  - oraclejdk8
+ - oraclejdk8
 install: true
 
+services:
+ - docker
+
+install:
+ - docker pull bigchaindb/bigchaindb
+ - docker run --interactive --rm --tty --volume $HOME/bigchaindb_docker:/data --env BIGCHAINDB_DATABASE_HOST=172.17.0.1 bigchaindb/bigchaindb -y configure mongodb
+ - docker run --detach --name=mongodb --publish=27017:27017 --restart=always --volume=$HOME/mongodb_docker/db:/data/db --volume=$HOME/mongodb_docker/configdb:/data/configdb mongo:3.4.9 --replSet=bigchain-rs
+ - docker run --detach --name=bigchaindb --publish=9984:9984 --restart=always --volume=$HOME/bigchaindb_docker:/data bigchaindb/bigchaindb start
+
 before_script:
-  - mvn install:install-file -Dfile=$TRAVIS_BUILD_DIR/libs/java-crypto-conditions-2.0.0-SNAPSHOT.jar -DgroupId=org.interledger -DartifactId=java-crypto-conditions -Dversion=2.0.0-SNAPSHOT -Dpackaging=jar
+ - mvn install:install-file -Dfile=$TRAVIS_BUILD_DIR/libs/java-crypto-conditions-2.0.0-SNAPSHOT.jar -DgroupId=org.interledger -DartifactId=java-crypto-conditions -Dversion=2.0.0-SNAPSHOT -Dpackaging=jar
 
 branches:
-  only:
-  - master
+ only:
+ - master
 
 script:
-  - mvn clean install
+ - mvn clean install

--- a/src/test/java/com/authenteq/api/BlocksApiTest.java
+++ b/src/test/java/com/authenteq/api/BlocksApiTest.java
@@ -1,5 +1,6 @@
 package com.authenteq.api;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -20,6 +21,7 @@ import com.authenteq.builders.BigchainDbTransactionBuilder;
 import com.authenteq.constants.BlockStatus;
 import com.authenteq.constants.Operations;
 import com.authenteq.model.Account;
+import com.authenteq.model.StatusCode;
 import com.authenteq.model.Transaction;
 
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
@@ -35,7 +37,7 @@ public class BlocksApiTest extends AbstractApiTest
 
 	/**
 	 * Test asset search.
-	 * @throws InterruptedException 
+	 * @throws InterruptedException
 	 */
 	@Test
 	public void testBlockSearch() throws InterruptedException {
@@ -48,17 +50,18 @@ public class BlocksApiTest extends AbstractApiTest
 				put( "ziddlename", "mname" );
 				put( "lastname", "Smith" );
 			}};
-			
+
 			Transaction transaction = BigchainDbTransactionBuilder
                       .init()
                       .addAssets(assetData, TreeMap.class)
                       .operation(Operations.CREATE)
                       .buildAndSign((EdDSAPublicKey) Account.publicKeyFromHex(publicKey), (EdDSAPrivateKey) Account.privateKeyFromHex(privateKey))
                       .sendTransaction();
-			
+
+			assertEquals(StatusCode.VALID, getStatus(transaction).getStatus());
 			assertFalse(BlocksApi.getBlocks(transaction.getId(), BlockStatus.VALID).isEmpty());
-			
-		} catch (IOException | InvalidKeySpecException e) {
+
+		} catch (IOException | InvalidKeySpecException | StatusException e) {
 			e.printStackTrace();
 		}
 	}

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,3 +1,4 @@
 test.api.url=http://localhost:9984
 test.app.id=2bbaf3ff
 test.app.key=c929b708177dcc8b9d58180082029b8d
+test.status.retries=300

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,3 +1,3 @@
-test.api.url=https://test.ipdb.io
+test.api.url=http://localhost:9984
 test.app.id=2bbaf3ff
 test.app.key=c929b708177dcc8b9d58180082029b8d


### PR DESCRIPTION
Hi!

Build fails because of dependency of test.ipdb.io.
I created a docker environment ([see tutorial](https://docs.bigchaindb.com/projects/server/en/latest/appendices/run-with-docker.html)) to test against in the travis-build.

I increased the number of retries to 300 in the test.properties. Wouldn't it be better to wait a little bit (like 10ms) in the method AbstractTest.getStatus instead of polling without a timeout?

Regards, Rokko